### PR TITLE
fix: configure @swc/jest to use automatic JSX runtime

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,7 +1,19 @@
 export default {
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|tsx)$': ['@swc/jest'],
+    '^.+\\.(ts|tsx)$': ['@swc/jest', {
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          tsx: true
+        },
+        transform: {
+          react: {
+            runtime: 'automatic'  // This matches our tsconfig.json "jsx": "react-jsx"
+          }
+        }
+      }
+    }]
   },
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',


### PR DESCRIPTION
- Updated jest.config.js to use automatic JSX runtime
- Matches tsconfig.json jsx:react-jsx setting
- Fixes React not defined error in tests