### PR TITLE
feat: move BPMN palette to right side of paper container

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,6 +6,7 @@
 :root {
   --header-height: 64px;
   --drawer-width: 240px;
+  --palette-width: 96px;
 }
 
 /* Global styles */
@@ -47,8 +48,19 @@ body {
 }
 
 .djs-palette {
-  position: fixed !important;
-  left: var(--drawer-width) !important;
+  position: absolute !important;
+  left: auto !important;
+  right: 0 !important;
+  top: 0 !important;
+  height: 100% !important;
+  z-index: 10;
+  background-color: #f8f9fa;
+  border-left: 1px solid #e9ecef;
+  width: var(--palette-width) !important;
+}
+
+.djs-palette.two-column {
+  width: var(--palette-width) !important;
 }
 
 .djs-container {

--- a/frontend/src/pages/ProcessDesigner/ProcessDesigner.tsx
+++ b/frontend/src/pages/ProcessDesigner/ProcessDesigner.tsx
@@ -188,6 +188,7 @@ const ProcessDesigner = () => {
           position: 'relative',
           bgcolor: '#fff',
           overflow: 'hidden',
+          mr: 'var(--palette-width)', // Space for palette
         }}
       >
         <div


### PR DESCRIPTION
- Add CSS variable for palette width
- Update palette positioning to be right-aligned
- Adjust paper container margin to accommodate palette
- Add proper styling with background and border