### PR TITLE
test: Fix navigation path and improve test mocks

### DIFF
--- a/frontend/src/pages/ProcessList/ProcessList.test.tsx
+++ b/frontend/src/pages/ProcessList/ProcessList.test.tsx
@@ -131,7 +131,9 @@ describe('ProcessList', () => {
     });
 
     // Verify navigation
-    expect(mockNavigate).toHaveBeenCalledWith('/instances/instance-1');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/processes/1/instances/instance-1'
+    );
   });
 
   it('handles process start error', async () => {


### PR DESCRIPTION
- Update ProcessList test to expect correct instance navigation path
- Improve ProcessDesigner test mocks for useNavigate and window.alert
- Add proper cleanup for window.alert mock in afterEach
- Replace require() with ES module imports