### PR TITLE
Feature/drop unused columns

### DIFF
--- a/backend/migrations/versions/009_update_process_table.py
+++ b/backend/migrations/versions/009_update_process_table.py
@@ -1,0 +1,53 @@
+"""Update process_definitions table to remove redundant columns
+
+Revision ID: 009
+Revises: 008
+Create Date: 2025-04-01 18:00:00.123456
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "009"
+down_revision: Union[str, None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop redundant columns from process_definitions and add index to process_versions."""
+    # Add index on process_versions.number for better query performance
+    op.create_index(
+        "ix_process_versions_number",
+        "process_versions",
+        ["number"],
+    )
+
+    # Drop columns from process_definitions that are now in process_versions
+    op.drop_column("process_definitions", "bpmn_xml")
+    op.drop_column("process_definitions", "updated_at")
+    op.drop_column("process_definitions", "version")
+
+
+def downgrade() -> None:
+    """Restore dropped columns and remove index."""
+    # Restore columns to process_definitions
+    op.add_column(
+        "process_definitions",
+        sa.Column("bpmn_xml", sa.Text(), nullable=False),
+    )
+    op.add_column(
+        "process_definitions",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.add_column(
+        "process_definitions",
+        sa.Column("version", sa.Integer(), nullable=False),
+    )
+
+    # Drop the index we added
+    op.drop_index("ix_process_versions_number", table_name="process_versions")

--- a/backend/src/pythmata/api/schemas/process.py
+++ b/backend/src/pythmata/api/schemas/process.py
@@ -38,9 +38,8 @@ class ProcessDefinitionBase(BaseModel):
     """Base schema for process definition."""
 
     name: str
-    bpmn_xml: str
-    version: int
     variable_definitions: List[ProcessVariableDefinition] = Field(default_factory=list)
+    current_version_id: Optional[UUID] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -49,11 +48,11 @@ class ProcessDefinitionCreate(BaseModel):
     """Schema for creating a process definition."""
 
     name: str
-    bpmn_xml: str
-    version: Optional[int] = 1  # Default to version 1 for new processes
+    bpmn_xml: str  # Initial BPMN XML for the first version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = Field(
         default_factory=list
     )
+    notes: Optional[str] = None  # Optional notes for the first version
 
     model_config = ConfigDict(extra="forbid")
 
@@ -62,9 +61,8 @@ class ProcessDefinitionUpdate(BaseModel):
     """Schema for updating a process definition."""
 
     name: Optional[str] = None
-    bpmn_xml: Optional[str] = None
-    version: Optional[int] = None  # Allow updating version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = None
+    current_version_id: Optional[UUID] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -74,7 +72,6 @@ class ProcessDefinitionResponse(ProcessDefinitionBase):
 
     id: UUID
     created_at: datetime
-    updated_at: datetime
     active_instances: int = 0
     total_instances: int = 0
 
@@ -260,7 +257,6 @@ class ProcessInstanceResponse(BaseModel):
     start_time: datetime
     end_time: Optional[datetime]
     created_at: datetime
-    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -292,7 +288,6 @@ class ScriptContent(BaseModel):
     """Schema for script content."""
 
     content: str
-    version: int = 1
 
     model_config = ConfigDict(extra="forbid")
 
@@ -304,9 +299,7 @@ class ScriptResponse(BaseModel):
     process_def_id: UUID
     node_id: str
     content: str
-    version: int
     created_at: datetime
-    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/src/pythmata/api/schemas/process/definitions.py
+++ b/backend/src/pythmata/api/schemas/process/definitions.py
@@ -7,15 +7,15 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from pythmata.api.schemas.process.variables import ProcessVariableDefinition
+from pythmata.api.schemas.process.versions import ProcessVersionResponse
 
 
 class ProcessDefinitionBase(BaseModel):
     """Base schema for process definition."""
 
     name: str
-    bpmn_xml: str
-    version: int
     variable_definitions: List[ProcessVariableDefinition] = Field(default_factory=list)
+    current_version_id: Optional[UUID] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -24,11 +24,11 @@ class ProcessDefinitionCreate(BaseModel):
     """Schema for creating a process definition."""
 
     name: str
-    bpmn_xml: str
-    version: Optional[int] = 1  # Default to version 1 for new processes
+    bpmn_xml: str  # Initial BPMN XML for the first version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = Field(
         default_factory=list
     )
+    notes: Optional[str] = None  # Optional notes for the first version
 
     model_config = ConfigDict(extra="forbid")
 
@@ -37,9 +37,8 @@ class ProcessDefinitionUpdate(BaseModel):
     """Schema for updating a process definition."""
 
     name: Optional[str] = None
-    bpmn_xml: Optional[str] = None
-    version: Optional[int] = None  # Allow updating version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = None
+    current_version_id: Optional[UUID] = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -49,8 +48,8 @@ class ProcessDefinitionResponse(ProcessDefinitionBase):
 
     id: UUID
     created_at: datetime
-    updated_at: datetime
     active_instances: int = 0
     total_instances: int = 0
+    current_version: Optional[ProcessVersionResponse] = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/backend/src/pythmata/api/schemas/process/versions.py
+++ b/backend/src/pythmata/api/schemas/process/versions.py
@@ -1,8 +1,19 @@
+"""Process version related schemas."""
+
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+
+class ProcessVersionCreate(BaseModel):
+    """Schema for creating a new process version."""
+
+    bpmn_xml: str
+    notes: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class ProcessVersionResponse(BaseModel):
@@ -14,5 +25,14 @@ class ProcessVersionResponse(BaseModel):
     bpmn_xml: str
     created_at: datetime
     notes: Optional[str] = None
+    is_current: bool = False
 
-    model_config = ConfigDict(from_attributes=True) 
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ProcessVersionUpdate(BaseModel):
+    """Schema for updating a process version."""
+
+    notes: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid") 

--- a/backend/src/pythmata/core/engine/events/timer_scheduler.py
+++ b/backend/src/pythmata/core/engine/events/timer_scheduler.py
@@ -228,13 +228,13 @@ class TimerScheduler:
             db = get_db()
             async with db.session() as session:
                 result = await session.execute(
-                    select(ProcessDefinition.id, ProcessDefinition.updated_at)
+                    select(ProcessDefinition.id)
                 )
                 definitions = result.all()
 
-                # Create a string representation of all definition IDs and update timestamps
+                # Create a string representation of all definition IDs
                 definitions_str = "|".join(
-                    f"{d.id}:{d.updated_at.isoformat()}" for d in definitions
+                    f"{d.id}" for d in definitions
                 )
 
                 # Use a simple hash function


### PR DESCRIPTION
**DO NOT MERGE YET.** 

This pull request includes significant changes to the process definitions and versions in the backend system. The changes primarily focus on restructuring the database schema, updating the API endpoints, and modifying the related schemas.

### Database Schema Updates:
* [`backend/migrations/versions/009_update_process_table.py`](diffhunk://#diff-e8764eb7d317f9b6871f0d8a815906c3ec2ebc54aecad1978381b8de32d63328R1-R83): Updated the `process_definitions` table to remove redundant columns and added a new column `current_version_id` with a foreign key constraint. Also, added an index to the `process_versions` table for better query performance.

### API Endpoint Modifications:
* [`backend/src/pythmata/api/routes/process_definitions.py`](diffhunk://#diff-f3f7ca235bf8ce948802d1d30df264594e81beb57cc504ffbb219bc3c2d882a6L122-L140): Removed version-related logic from the `create_process` and `update_process` functions, and added logic to handle the new `current_version_id` field. [[1]](diffhunk://#diff-f3f7ca235bf8ce948802d1d30df264594e81beb57cc504ffbb219bc3c2d882a6L122-L140) [[2]](diffhunk://#diff-f3f7ca235bf8ce948802d1d30df264594e81beb57cc504ffbb219bc3c2d882a6L151-R165) [[3]](diffhunk://#diff-f3f7ca235bf8ce948802d1d30df264594e81beb57cc504ffbb219bc3c2d882a6R195-L201) [[4]](diffhunk://#diff-f3f7ca235bf8ce948802d1d30df264594e81beb57cc504ffbb219bc3c2d882a6L210-R248)

### Schema Changes:
* [`backend/src/pythmata/api/schemas/process.py`](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L41-R42): Updated various schemas to remove the `version` field and add the `current_version_id` field. Also, added a new `notes` field for the initial version in the `ProcessDefinitionCreate` schema. [[1]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L41-R42) [[2]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L52-R55) [[3]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L65-R65) [[4]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L77) [[5]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L263) [[6]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L295) [[7]](diffhunk://#diff-f895bb107a9db8057a47ce815c1246d6fb74930d44730af27317b37c7edba796L307-L309)
* [`backend/src/pythmata/api/schemas/process/definitions.py`](diffhunk://#diff-a222d46b2935ca74ae4f8ead44716dde9f488db5a24495ed13a5ec7c0768a217R10-R18): Similar updates as in `process.py` to reflect the changes in process definitions and versions. [[1]](diffhunk://#diff-a222d46b2935ca74ae4f8ead44716dde9f488db5a24495ed13a5ec7c0768a217R10-R18) [[2]](diffhunk://#diff-a222d46b2935ca74ae4f8ead44716dde9f488db5a24495ed13a5ec7c0768a217L27-R31) [[3]](diffhunk://#diff-a222d46b2935ca74ae4f8ead44716dde9f488db5a24495ed13a5ec7c0768a217L40-R41) [[4]](diffhunk://#diff-a222d46b2935ca74ae4f8ead44716dde9f488db5a24495ed13a5ec7c0768a217L52-R53)
* [`backend/src/pythmata/api/schemas/process/versions.py`](diffhunk://#diff-37f4abfe461dd3215a99908103af7577e3558981f38901d933b1ccbbde4317eaR1-R18): Added new schemas for creating and updating process versions, and updated the response schema to include an `is_current` field. [[1]](diffhunk://#diff-37f4abfe461dd3215a99908103af7577e3558981f38901d933b1ccbbde4317eaR1-R18) [[2]](diffhunk://#diff-37f4abfe461dd3215a99908103af7577e3558981f38901d933b1ccbbde4317eaR28-R38)

### Model Adjustments:
* [`backend/src/pythmata/models/process.py`](diffhunk://#diff-1df84ee432698ae0da0ab77b04d2ce46dfded7aec45c0a3647b5550b4df75e72R65-L80): Updated the `ProcessDefinition` model to include the `current_version_id` field and relationships. Removed the `version` and `bpmn_xml` fields. [[1]](diffhunk://#diff-1df84ee432698ae0da0ab77b04d2ce46dfded7aec45c0a3647b5550b4df75e72R65-L80) [[2]](diffhunk://#diff-1df84ee432698ae0da0ab77b04d2ce46dfded7aec45c0a3647b5550b4df75e72L90-R100) [[3]](diffhunk://#diff-1df84ee432698ae0da0ab77b04d2ce46dfded7aec45c0a3647b5550b4df75e72L126-L131)

### Additional Changes:
* [`backend/src/pythmata/core/engine/events/timer_scheduler.py`](diffhunk://#diff-69aed54448d05021eec1635f73a5638d9406c0caa597ded370d0268dea6a74cfL231-R237): Updated the `_get_process_definitions_hash` method to reflect the removal of the `updated_at` field.