### PR TITLE
Feature/add conflict resolution

### DIFF
--- a/backend/src/pythmata/api/schemas/process/definitions.py
+++ b/backend/src/pythmata/api/schemas/process/definitions.py
@@ -38,9 +38,9 @@ class ProcessDefinitionUpdate(BaseModel):
 
     name: Optional[str] = None
     bpmn_xml: Optional[str] = None
-    version: Optional[int] = None  # Allow updating version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = None
     notes: Optional[str] = None  # Add notes for the new version
+    expected_updated_at: datetime # Add timestamp for optimistic locking
 
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/src/pythmata/api/schemas/process/definitions.py
+++ b/backend/src/pythmata/api/schemas/process/definitions.py
@@ -40,6 +40,7 @@ class ProcessDefinitionUpdate(BaseModel):
     bpmn_xml: Optional[str] = None
     version: Optional[int] = None  # Allow updating version
     variable_definitions: Optional[List[ProcessVariableDefinition]] = None
+    notes: Optional[str] = None  # Add notes for the new version
 
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/tests/api/test_process_definitions.py
+++ b/backend/tests/api/test_process_definitions.py
@@ -1,14 +1,26 @@
 import json
+from datetime import datetime, timezone
+from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 from pydantic import TypeAdapter
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from pythmata.api.routes import router
-from pythmata.api.schemas import ProcessDefinitionResponse, ProcessStats
-from pythmata.models.process import ProcessDefinition, ProcessInstance, ProcessStatus
+from pythmata.api.schemas import (
+    ProcessDefinitionResponse,
+    ProcessStats,
+    ProcessVersionResponse,
+)
+from pythmata.models.process import (
+    ProcessDefinition,
+    ProcessInstance,
+    ProcessStatus,
+    ProcessVersion,
+)
 from tests.data.process_samples import SIMPLE_PROCESS_XML
 
 # Setup test application
@@ -28,6 +40,18 @@ async def process_definition(session: AsyncSession) -> ProcessDefinition:
     session.add(definition)
     await session.commit()
     await session.refresh(definition)
+
+    # Add initial version entry
+    initial_version = ProcessVersion(
+        process_id=definition.id,
+        number=1,
+        bpmn_xml=SIMPLE_PROCESS_XML,
+        notes="Initial version",
+    )
+    session.add(initial_version)
+    await session.commit()
+    await session.refresh(definition)
+
     return definition
 
 
@@ -80,6 +104,45 @@ async def process_with_mixed_status_instances(
 
     await session.commit()
     return process_definition, status_counts
+
+
+@pytest.fixture
+async def process_with_multiple_versions(
+    session: AsyncSession, process_definition: ProcessDefinition
+) -> ProcessDefinition:
+    """Create a process definition with multiple versions."""
+    # Version 1 already created by process_definition fixture
+    version2_xml = "<bpmn>Version 2</bpmn>"
+    version3_xml = "<bpmn>Version 3</bpmn>"
+
+    version2 = ProcessVersion(
+        process_id=process_definition.id,
+        number=2,
+        bpmn_xml=version2_xml,
+        notes="Second version",
+        created_at=datetime.now(timezone.utc),
+    )
+    version3 = ProcessVersion(
+        process_id=process_definition.id,
+        number=3,
+        bpmn_xml=version3_xml,
+        notes="Third version",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    session.add_all([version2, version3])
+
+    # Update the main process definition to reflect the latest version info
+    process_definition.version = 3
+    process_definition.bpmn_xml = version3_xml
+    session.add(process_definition)
+
+    await session.commit()
+    await session.refresh(process_definition)
+
+    # Eager load versions for assertions later
+    await session.refresh(process_definition, attribute_names=["versions"])
+    return process_definition
 
 
 async def test_get_processes_serialization(
@@ -283,3 +346,105 @@ async def test_multiple_processes_instance_counting(
     processes = data_list["items"]
     assert processes[0]["name"] == "Process 2"  # Created later
     assert processes[1]["name"] == "Process 1"  # Created first
+
+
+# --- Process Version Tests ---
+
+
+async def test_get_process_versions(
+    async_client: AsyncClient,
+    process_with_multiple_versions: ProcessDefinition,
+):
+    """Test GET /processes/{process_id}/versions endpoint."""
+    process = process_with_multiple_versions
+    process_id = process.id
+
+    response = await async_client.get(f"/processes/{process_id}/versions")
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert isinstance(data, list)
+    assert len(data) == 3
+
+    # Validate structure using ProcessVersionResponse schema
+    validated_versions = TypeAdapter(list[ProcessVersionResponse]).validate_python(data)
+
+    # Versions should be ordered by number descending
+    assert validated_versions[0].number == 3
+    assert validated_versions[1].number == 2
+    assert validated_versions[2].number == 1
+
+    # Check details of the latest version
+    assert validated_versions[0].process_id == process_id
+    assert validated_versions[0].bpmn_xml == "<bpmn>Version 3</bpmn>"
+    assert validated_versions[0].notes == "Third version"
+
+    # Check details of the first version
+    assert validated_versions[2].process_id == process_id
+    assert validated_versions[2].bpmn_xml == SIMPLE_PROCESS_XML
+    assert validated_versions[2].notes == "Initial version"
+
+
+async def test_get_process_versions_not_found(async_client: AsyncClient):
+    """Test GET /processes/{process_id}/versions for non-existent process."""
+    non_existent_id = uuid4()
+    response = await async_client.get(f"/processes/{non_existent_id}/versions")
+    assert response.status_code == 404
+    assert "Process definition not found" in response.json()["detail"]
+
+
+async def test_create_process_creates_initial_version(
+    async_client: AsyncClient, session: AsyncSession
+):
+    """Test that POST /processes creates an initial ProcessVersion entry."""
+    process_name = "New Process with Version"
+    process_xml = "<bpmn>Initial XML</bpmn>"
+    payload = {
+        "name": process_name,
+        "bpmn_xml": process_xml,
+        "variable_definitions": [],
+    }
+
+    response = await async_client.post("/processes", json=payload)
+    assert response.status_code == 200
+
+    created_process_data = response.json()["data"]
+    process_id = created_process_data["id"]
+
+    # Verify the ProcessDefinition was created correctly
+    assert created_process_data["name"] == process_name
+    assert created_process_data["version"] == 1
+    assert created_process_data["bpmn_xml"] == process_xml
+
+    # Now verify the ProcessVersion was created in the database
+    result = await session.execute(
+        select(ProcessVersion).filter(ProcessVersion.process_id == process_id)
+    )
+    versions = result.scalars().all()
+
+    assert len(versions) == 1
+    initial_version = versions[0]
+    assert initial_version.number == 1
+    assert initial_version.bpmn_xml == process_xml
+    assert initial_version.notes == "Initial version created."
+    assert str(initial_version.process_id) == process_id
+
+
+async def test_get_process_versions_single_version(
+    async_client: AsyncClient, process_definition: ProcessDefinition
+):
+    """Test GET /processes/{process_id}/versions when only one version exists."""
+    process_id = process_definition.id
+
+    response = await async_client.get(f"/processes/{process_id}/versions")
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+    validated_version = ProcessVersionResponse.model_validate(data[0])
+    assert validated_version.number == 1
+    assert validated_version.process_id == process_id
+    assert validated_version.bpmn_xml == SIMPLE_PROCESS_XML
+    assert validated_version.notes == "Initial version"


### PR DESCRIPTION
I have updated the `ProcessDefinitionUpdate` schema to include the `expected_updated_at` field and modified the `update_process` function in `backend/src/pythmata/api/routes/process_definitions.py` to perform the optimistic locking check before applying updates.

If the `expected_updated_at` timestamp provided in the request body does not match the current `updated_at` timestamp of the process definition in the database, a `409 Conflict` error will be raised, preventing stale updates. Otherwise, the update proceeds as before. The existing error handling ensures transactions are rolled back in case of a conflict or any other exception.
